### PR TITLE
Feature: Add links for GitHub badges on issues and version 

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2021, Arizona Board of Regents'
 author = 'Chun Ly, UA Research Data Repository (ReDATA) Team'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.3.0'
+release = 'v0.3.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/source/repos.rst
+++ b/source/repos.rst
@@ -98,30 +98,39 @@ Below summarizes open and closed issues and pull requests.
 .. _`cognoma's`: https://github.com/cognoma/figshare
 
 .. |ldcoolp_version| image:: https://img.shields.io/github/v/tag/UAL-RE/LD-Cool-P?label=%20
+   :target: https://github.com/UAL-RE/LD-Cool-P/releases/latest
    :alt: LD-Cool-P GitHub tag version
 
 .. |ReBACH_version| image:: https://img.shields.io/github/v/tag/UAL-RE/ReBACH?label=%20
+   :target: https://github.com/UAL-RE/ReBACH/releases/latest
    :alt: ReBACH GitHub tag version
 
 .. |ReQUIAM_version| image:: https://img.shields.io/github/v/tag/UAL-RE/ReQUIAM?label=%20
+   :target: https://github.com/UAL-RE/ReQUIAM/releases/latest
    :alt: ReQUIAM GitHub tag version
 
 .. |ReQUIAM_csv_version| image:: https://img.shields.io/github/v/tag/UAL-RE/ReQUIAM_csv?label=%20
+   :target: https://github.com/UAL-RE/ReQUIAM_csv/releases/latest
    :alt: ReQUIAM_csv GitHub tag version
 
 .. |ldcoolp-figshare_version| image:: https://img.shields.io/github/v/tag/UAL-RE/ldcoolp-figshare?label=%20
+   :target: https://github.com/UAL-RE/ldcoolp-figshare/releases/latest
    :alt: ldcoolp-figshare GitHub tag version
 
 .. |figshare_version| image:: https://img.shields.io/github/v/tag/UAL-RE/figshare?label=%20
+   :target: https://github.com/UAL-RE/figshare/releases/latest
    :alt: figshare GitHub tag version
 
 .. |redata-commons_version| image:: https://img.shields.io/github/v/tag/UAL-RE/redata-commons?label=%20
+   :target: https://github.com/UAL-RE/redata-commons/releases/latest
    :alt: redata-commons GitHub tag version
 
 .. |redata-docs_version| image:: https://img.shields.io/github/v/tag/UAL-RE/redata-docs?label=%20
+   :target: https://github.com/UAL-RE/redata-docs/releases/latest
    :alt: redata-docs GitHub tag version
 
 .. |redata-iac_version| image:: https://img.shields.io/github/v/tag/UAL-RE/redata-iac?label=%20
+   :target: https://github.com/UAL-RE/redata-iac/releases/latest
    :alt: redata-iac GitHub tag version
 
 .. __: https://github.com/UAL-RE/LD-Cool-P/blob/master/CHANGELOG.md

--- a/source/repos.rst
+++ b/source/repos.rst
@@ -139,97 +139,129 @@ Below summarizes open and closed issues and pull requests.
 .. __: https://github.com/UAL-RE/redata-commons/blob/main/CHANGELOG.md
 
 .. |ldcoolp_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/LD-Cool-P?color=green&label=open
+   :target: https://github.com/UAL-RE/LD-Cool-P/issues?q=is:open
    :alt: LD-Cool-P GitHub open issues
 
 .. |ldcoolp_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/LD-Cool-P?color=red&label=closed
+   :target: https://github.com/UAL-RE/LD-Cool-P/issues?q=is:closed
    :alt: LD-Cool-P Github closed issues
 
 .. |ldcoolp_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/LD-Cool-P?color=green&label=open
+   :target: https://github.com/UAL-RE/LD-Cool-P/pulls?q=is:open
    :alt: LD-Cool-P GitHub open PRs
 
 .. |ldcoolp_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/LD-Cool-P?color=red&label=closed
+   :target: https://github.com/UAL-RE/LD-Cool-P/pulls?q=is:closed
    :alt: LD-Cool-P Github closed PRs
 
 .. |ReBACH_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/ReBACH?color=green&label=open
+   :target: https://github.com/UAL-RE/ReBACH/issues?q=is:open
    :alt: ReBACH GitHub open issues
 
 .. |ReBACH_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/ReBACH?color=red&label=closed
+   :target: https://github.com/UAL-RE/ReBACH/issues?q=is:closed
    :alt: ReBACH Github closed issues
 
 .. |ReBACH_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/ReBACH?color=green&label=open
+   :target: https://github.com/UAL-RE/ReBACH/pulls?q=is:open
    :alt: ReBACH GitHub open PRs
 
 .. |ReBACH_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/ReBACH?color=red&label=closed
+   :target: https://github.com/UAL-RE/ReBACH/pulls?q=is:closed
    :alt: ReBACH Github closed PRs
 
 .. |ReQUIAM_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/ReQUIAM?color=green&label=open
+   :target: https://github.com/UAL-RE/ReQUIAM/issues?q=is:open
    :alt: ReQUIAM GitHub open issues
 
 .. |ReQUIAM_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/ReQUIAM?color=red&label=closed
+   :target: https://github.com/UAL-RE/ReQUIAM/issues?q=is:closed
    :alt: ReQUIAM Github closed issues
 
 .. |ReQUIAM_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/ReQUIAM?color=green&label=open
+   :target: https://github.com/UAL-RE/ReQUIAM/pulls?q=is:open
    :alt: ReQUIAM GitHub open PRs
 
 .. |ReQUIAM_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/ReQUIAM?color=red&label=closed
+   :target: https://github.com/UAL-RE/ReQUIAM/pulls?q=is:closed
    :alt: ReQUIAM Github closed PRs
 
 .. |ReQUIAM_csv_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/ReQUIAM_csv?color=green&label=open
+   :target: https://github.com/UAL-RE/ReQUIAM_csv/issues?q=is:open
    :alt: ReQUIAM_csv GitHub open issues
 
 .. |ReQUIAM_csv_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/ReQUIAM_csv?color=red&label=closed
+   :target: https://github.com/UAL-RE/ReQUIAM_csv/issues?q=is:closed
    :alt: ReQUIAM_csv Github closed issues
 
 .. |ReQUIAM_csv_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/ReQUIAM_csv?color=green&label=open
+   :target: https://github.com/UAL-RE/ReQUIAM_csv/pulls?q=is:open
    :alt: ReQUIAM_csv GitHub open PRs
 
 .. |ReQUIAM_csv_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/ReQUIAM_csv?color=red&label=closed
+   :target: https://github.com/UAL-RE/ReQUIAM_csv/pulls?q=is:closed
    :alt: ReQUIAM_csv Github closed PRs
 
 .. |ldcoolp-figshare_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/ldcoolp-figshare?color=green&label=open
+   :target: https://github.com/UAL-RE/ldcoolp-figshare/issues?q=is:open
    :alt: ldcoolp-figshare GitHub open issues
 
 .. |ldcoolp-figshare_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/ldcoolp-figshare?color=red&label=closed
+   :target: https://github.com/UAL-RE/ldcoolp-figshare/issues?q=is:closed
    :alt: ldcoolp-figshare GitHub closed issues
 
 .. |ldcoolp-figshare_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/ldcoolp-figshare?color=green&label=open
+   :target: https://github.com/UAL-RE/ldcoolp-figshare/pulls?q=is:open
    :alt: ldcoolp-figshare GitHub open PRs
 
 .. |ldcoolp-figshare_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/ldcoolp-figshare?color=red&label=closed
+   :target: https://github.com/UAL-RE/ldcoolp-figshare/pulls?q=is:closed
    :alt: ldcoolp-figshare GitHub closed PRs
 
 .. |redata-commons_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/redata-commons?color=green&label=open
+   :target: https://github.com/UAL-RE/redata-commons/issues?q=is:open
    :alt: redata-commons GitHub open issues
 
 .. |redata-commons_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/redata-commons?color=red&label=closed
+   :target: https://github.com/UAL-RE/redata-commons/issues?q=is:closed
    :alt: redata-commons GitHub closed issues
 
 .. |redata-commons_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/redata-commons?color=green&label=open
+   :target: https://github.com/UAL-RE/redata-commons/pulls?q=is:open
    :alt: redata-commons GitHub open PRs
 
 .. |redata-commons_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/redata-commons?color=red&label=closed
+   :target: https://github.com/UAL-RE/redata-commons/pulls?q=is:closed
    :alt: redata-commons GitHub closed PRs
 
 .. |redata-docs_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/redata-docs?color=green&label=open
+   :target: https://github.com/UAL-RE/redata-docs/issues?q=is:open
    :alt: redata-docs GitHub open issues
 
 .. |redata-docs_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/redata-docs?color=red&label=closed
+   :target: https://github.com/UAL-RE/redata-docs/issues?q=is:closed
    :alt: redata-docs GitHub closed issues
 
 .. |redata-docs_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/redata-docs?color=green&label=open
+   :target: https://github.com/UAL-RE/redata-docs/pulls?q=is:open
    :alt: redata-docs GitHub open PRs
 
 .. |redata-docs_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/redata-docs?color=red&label=closed
+   :target: https://github.com/UAL-RE/redata-docs/pulls?q=is:closed
    :alt: redata-docs GitHub closed PRs
 
 .. |redata-iac_iss| image:: https://img.shields.io/github/issues-raw/UAL-RE/redata-iac?color=green&label=open
+   :target: https://github.com/UAL-RE/redata-iac/issues?q=is:open
    :alt: redata-iac GitHub open issues
 
 .. |redata-iac_iss2| image:: https://img.shields.io/github/issues-closed-raw/UAL-RE/redata-iac?color=red&label=closed
+   :target: https://github.com/UAL-RE/redata-iac/issues?q=is:closed
    :alt: redata-iac GitHub closed issues
 
 .. |redata-iac_pr| image:: https://img.shields.io/github/issues-pr-raw/UAL-RE/redata-iac?color=green&label=open
+   :target: https://github.com/UAL-RE/redata-iac/pulls?q=is:open
    :alt: redata-iac GitHub open PRs
 
 .. |redata-iac_pr2| image:: https://img.shields.io/github/issues-pr-closed-raw/UAL-RE/redata-iac?color=red&label=closed
+   :target: https://github.com/UAL-RE/redata-iac/pulls?q=is:closed
    :alt: redata-iac GitHub closed PRs


### PR DESCRIPTION
Closes #11

Commit history:
- Add target for GitHub badges on issues and PRs
- Add target for GitHub badges on release version
- Bump version: v0.3.0 -> v0.3.1
