### PR TITLE
fixed issue 16 by removing an additional README__ anchor

### DIFF
--- a/source/repos.rst
+++ b/source/repos.rst
@@ -141,8 +141,6 @@ Below summarizes open and closed issues and pull requests.
 
 .. __: https://github.com/UAL-RE/ReQUIAM/blob/master/CHANGELOG.md
 
-.. __: https://github.com/UAL-RE/ReQUIAM/blob/master/README.md
-
 .. __: https://github.com/UAL-RE/ldcoolp-figshare/blob/main/CHANGELOG.md
 
 .. __: https://github.com/UAL-RE/redata-commons/blob/main/CHANGELOG.md


### PR DESCRIPTION
The broken links were due to the additional anchor  (pointing to README__ for ReQuiam) at the bottom of repos.rst.  Please see  the latest build at https://redata.readthedocs.io/en/documentation-16-update-repos.rst/